### PR TITLE
Add webhook exclude list

### DIFF
--- a/admin_server.lua
+++ b/admin_server.lua
@@ -189,12 +189,9 @@ RegisterCommand("ea_testWebhook", function(source, args, rawCommand)
 	end
 end, false)
 
-RegisterCommand("ea_excludeWebhook", function(source, args, rawCommand)
+RegisterCommand("ea_excludeWebhookFeature", function(source, args, rawCommand)
     if DoesPlayerHavePermission(source, "easyadmin.manageserver") then
-        for i, exclude in pairs(args) do
-            excludedWebhookFeatures = {}
-            table.insert(excludedWebhookFeatures, exclude)
-        end
+        ExcludedWebhookFeatures = Set(args)
         PrintDebugMessage("Webhook excludes set")
     end
 end, false)
@@ -1020,7 +1017,7 @@ Citizen.CreateThread(function()
 	
 	function SendWebhookMessage(webhook,message,feature)
 		moderationNotification = GetConvar("ea_moderationNotification", "false")
-		if webhook ~= "false" and ExcludedWebhookFeatures[feature] ~= nil then
+		if webhook ~= "false" and ExcludedWebhookFeatures[feature] ~= true then
 			PerformHttpRequest(webhook, function(err, text, headers) end, 'POST', json.encode({content = message}), { ['Content-Type'] = 'application/json' })
 		end
 	end

--- a/admin_server.lua
+++ b/admin_server.lua
@@ -16,9 +16,6 @@ ChatReminders = {}
 
 ExcludedWebhookFeatures = {}
 
-
-
-
 Citizen.CreateThread(function()
 	while true do 
 		Wait(20000)

--- a/util_shared.lua
+++ b/util_shared.lua
@@ -43,3 +43,10 @@ function math.round(num, numDecimalPlaces)
 	end
 	return math.floor(num + 0.5)
 end
+
+--- http://www.lua.org/pil/11.5.html
+function Set (list)
+	local set = {}
+	for _, l in ipairs(list) do set[l] = true end
+	return set
+end


### PR DESCRIPTION
This PR adds the functionality to exclude admin features from the webhook messages.

Features that can be disabled:

- kick
- ban
- slap
- teleport
- freeze

To use this feature, similar to ea_addReminder, a command must be called. This can easily be added to the server.cfg.

Example:

Do not include teleport and freeze messages in the webhook messages:

`ea_excludeWebhookFeature freeze teleport`