### PR TITLE
Too Many RAM usage Fix

### DIFF
--- a/admin_client.lua
+++ b/admin_client.lua
@@ -47,7 +47,9 @@ AddEventHandler("EasyAdmin:fillBanlist", function(thebanlist)
 end)
 
 AddEventHandler("EasyAdmin:fillCachedPlayers", function(thecached)
-	cachedplayers = thecached
+	if permission.ban then
+		cachedplayers = thecached
+	end
 end)
 
 AddEventHandler("EasyAdmin:GetPlayerList", function(players)


### PR DESCRIPTION
This fix the resource warning due to the excesive ram usage for non admin users when a lot of people joins the server