### PR TITLE
Fixed searching by BanID

### DIFF
--- a/gui_c.lua
+++ b/gui_c.lua
@@ -759,7 +759,7 @@ function GenerateMenu() -- this is a big ass function
 					if foundBan then
 						break
 					end
-					if theBanned.banid == result then
+					if tostring(theBanned.banid) == result then
 						foundBan=true
 						foundBanid=i
 						break


### PR DESCRIPTION
When I tested the latest version of easyadmin and tried to search for a ban by ID, it returned a random or incorrect ban and after some time I found out that BanID is a number and input is a string and after comparing these two lua values it returned false so I replaced BanID with a string using the tostring() function and everything works.