### PR TITLE
add Keywords

### DIFF
--- a/admin_server.lua
+++ b/admin_server.lua
@@ -312,11 +312,11 @@ end
 
 RegisterCommand("ea_addShortcut", function(source, args, rawCommand)
 	if args[2] and DoesPlayerHavePermission(source, "easyadmin.manageserver") then
-		local keyword = args[1]
+		local shortcut = args[1]
 		local text = table.concat(args, " ", 2)
 
-		PrintDebugMessage("added '"..keyword.." -> "..text.."' as a Keyword", 3)
-		MessageShortcuts[keyword] = text
+		PrintDebugMessage("added '"..shortcut.." -> "..text.."' as a shortcut", 3)
+		MessageShortcuts[shortcut] = text
 	end
 end)
 

--- a/admin_server.lua
+++ b/admin_server.lua
@@ -310,13 +310,13 @@ function DoesPlayerHavePermission(player, object)
 	return haspermission
 end
 
-RegisterCommand("ea_addKeyword", function(source, args, rawCommand)
+RegisterCommand("ea_addShortcut", function(source, args, rawCommand)
 	if args[2] and DoesPlayerHavePermission(source, "easyadmin.manageserver") then
 		local keyword = args[1]
 		local text = table.concat(args, " ", 2)
 
 		PrintDebugMessage("added '"..keyword.." -> "..text.."' as a Keyword", 3)
-		MessageKeywords[keyword] = text
+		MessageShortcuts[keyword] = text
 	end
 end)
 
@@ -556,7 +556,7 @@ Citizen.CreateThread(function()
 	RegisterServerEvent("EasyAdmin:kickPlayer")
 	AddEventHandler('EasyAdmin:kickPlayer', function(playerId,reason)
 		if DoesPlayerHavePermission(source,"easyadmin.kick") and not DoesPlayerHavePermission(playerId,"easyadmin.immune") then
-			reason = formatKeyWords(reason)
+			reason = formatShortcuts(reason)
 			SendWebhookMessage(moderationNotification,string.format(GetLocalisedText("adminkickedplayer"), getName(source, false, true), getName(playerId, true, true), reason), "kick", 16711680)
 			PrintDebugMessage("Kicking Player "..getName(source, true).." for "..reason, 3)
 			DropPlayer(playerId, string.format(GetLocalisedText("kicked"), getName(source), reason) )
@@ -640,7 +640,7 @@ Citizen.CreateThread(function()
 					return false
 				end
 
-				reason = formatKeyWords(reason).. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
+				reason = formatShortcuts(reason).. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
 				local ban = {banid = GetFreshBanId(), name = username,identifiers = bannedIdentifiers, banner = getName(source, true), reason = reason, expire = expires }
 				updateBlacklist( ban )
 				PrintDebugMessage("Player "..getName(source,true).." banned player "..CachedPlayers[playerId].name.." for "..reason, 3)
@@ -665,7 +665,7 @@ Citizen.CreateThread(function()
 					return false
 				end
 
-				reason = formatKeyWords(reason).. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
+				reason = formatShortcuts(reason).. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
 				local ban = {banid = GetFreshBanId(), name = username,identifiers = bannedIdentifiers, banner = getName(source), reason = reason, expire = expires }
 				updateBlacklist( ban )
 				PrintDebugMessage("Player "..getName(source,true).." offline banned player "..CachedPlayers[playerId].name.." for "..reason, 3)
@@ -691,7 +691,7 @@ Citizen.CreateThread(function()
 		elseif not expires then 
 			expires = 10444633200
 		end
-		reason = formatKeyWords(reason).. string.format(GetLocalisedText("reasonadd"), getName(tostring(playerId) or "?"), "Console" )
+		reason = formatShortcuts(reason).. string.format(GetLocalisedText("reasonadd"), getName(tostring(playerId) or "?"), "Console" )
 		local ban = {banid = GetFreshBanId(), name = bannedUsername,identifiers = bannedIdentifiers,  banner = "Unknown", reason = reason, expire = expires or 10444633200 }
 		updateBlacklist( ban )
 		
@@ -1307,7 +1307,7 @@ Citizen.CreateThread(function()
 	AddEventHandler('EasyAdmin:warnPlayer', function(id, reason)
 		local src = source
 		if DoesPlayerHavePermission(src,"easyadmin.warn") and not DoesPlayerHavePermission(id,"easyadmin.immune") then
-			reason = formatKeyWords(reason)
+			reason = formatShortcuts(reason)
 			local maxWarnings = GetConvarInt("ea_maxWarnings", 3)
 			if not WarnedPlayers[id] then
 				WarnedPlayers[id] = {name = getName(id, true), identifiers = getAllPlayerIdentifiers(id), warns = 0}
@@ -1616,7 +1616,7 @@ MutedPlayers = {} -- DO NOT TOUCH THIS
 CachedPlayers = {} -- DO NOT TOUCH THIS
 OnlineAdmins = {} -- DO NOT TOUCH THIS
 ChatReminders = {} -- DO NOT TOUCH THIS
-MessageKeywords = {} -- DO NOT TOUCH THIS
+MessageShortcuts = {} -- DO NOT TOUCH THIS
 WarnedPlayers = {}
 cooldowns = {}
 -- DO NOT TOUCH THESE

--- a/admin_server.lua
+++ b/admin_server.lua
@@ -310,6 +310,15 @@ function DoesPlayerHavePermission(player, object)
 	return haspermission
 end
 
+RegisterCommand("ea_addKeyword", function(source, args, rawCommand)
+	if args[2] and DoesPlayerHavePermission(source, "easyadmin.manageserver") then
+		local keyword = args[1]
+		local text = table.concat(args, " ", 2)
+
+		PrintDebugMessage("added '"..keyword.." -> "..text.."' as a Keyword", 3)
+		MessageKeywords[keyword] = text
+	end
+end)
 
 RegisterCommand("ea_addReminder", function(source, args, rawCommand)
 	if args[1] and DoesPlayerHavePermission(source,"easyadmin.manageserver") then
@@ -547,6 +556,7 @@ Citizen.CreateThread(function()
 	RegisterServerEvent("EasyAdmin:kickPlayer")
 	AddEventHandler('EasyAdmin:kickPlayer', function(playerId,reason)
 		if DoesPlayerHavePermission(source,"easyadmin.kick") and not DoesPlayerHavePermission(playerId,"easyadmin.immune") then
+			reason = formatKeyWords(reason)
 			SendWebhookMessage(moderationNotification,string.format(GetLocalisedText("adminkickedplayer"), getName(source, false, true), getName(playerId, true, true), reason), "kick", 16711680)
 			PrintDebugMessage("Kicking Player "..getName(source, true).." for "..reason, 3)
 			DropPlayer(playerId, string.format(GetLocalisedText("kicked"), getName(source), reason) )
@@ -630,7 +640,7 @@ Citizen.CreateThread(function()
 					return false
 				end
 
-				reason = reason.. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
+				reason = formatKeyWords(reason).. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
 				local ban = {banid = GetFreshBanId(), name = username,identifiers = bannedIdentifiers, banner = getName(source, true), reason = reason, expire = expires }
 				updateBlacklist( ban )
 				PrintDebugMessage("Player "..getName(source,true).." banned player "..CachedPlayers[playerId].name.." for "..reason, 3)
@@ -655,7 +665,7 @@ Citizen.CreateThread(function()
 					return false
 				end
 
-				reason = reason.. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
+				reason = formatKeyWords(reason).. string.format(GetLocalisedText("reasonadd"), CachedPlayers[playerId].name, getName(source) )
 				local ban = {banid = GetFreshBanId(), name = username,identifiers = bannedIdentifiers, banner = getName(source), reason = reason, expire = expires }
 				updateBlacklist( ban )
 				PrintDebugMessage("Player "..getName(source,true).." offline banned player "..CachedPlayers[playerId].name.." for "..reason, 3)
@@ -681,7 +691,7 @@ Citizen.CreateThread(function()
 		elseif not expires then 
 			expires = 10444633200
 		end
-		reason = reason.. string.format(GetLocalisedText("reasonadd"), getName(tostring(playerId) or "?"), "Console" )
+		reason = formatKeyWords(reason).. string.format(GetLocalisedText("reasonadd"), getName(tostring(playerId) or "?"), "Console" )
 		local ban = {banid = GetFreshBanId(), name = bannedUsername,identifiers = bannedIdentifiers,  banner = "Unknown", reason = reason, expire = expires or 10444633200 }
 		updateBlacklist( ban )
 		
@@ -1297,6 +1307,7 @@ Citizen.CreateThread(function()
 	AddEventHandler('EasyAdmin:warnPlayer', function(id, reason)
 		local src = source
 		if DoesPlayerHavePermission(src,"easyadmin.warn") and not DoesPlayerHavePermission(id,"easyadmin.immune") then
+			reason = formatKeyWords(reason)
 			local maxWarnings = GetConvarInt("ea_maxWarnings", 3)
 			if not WarnedPlayers[id] then
 				WarnedPlayers[id] = {name = getName(id, true), identifiers = getAllPlayerIdentifiers(id), warns = 0}
@@ -1605,6 +1616,7 @@ MutedPlayers = {} -- DO NOT TOUCH THIS
 CachedPlayers = {} -- DO NOT TOUCH THIS
 OnlineAdmins = {} -- DO NOT TOUCH THIS
 ChatReminders = {} -- DO NOT TOUCH THIS
+MessageKeywords = {} -- DO NOT TOUCH THIS
 WarnedPlayers = {}
 cooldowns = {}
 -- DO NOT TOUCH THESE

--- a/util_shared.lua
+++ b/util_shared.lua
@@ -65,8 +65,8 @@ end
 
 function formatShortcuts(thisstring)
 	local cleanString = string.gsub(string.lower(thisstring), " ", "")
-	for keyword,value in pairs(MessageShortcuts) do
-		if string.lower(keyword) == cleanString then
+	for shortcut,value in pairs(MessageShortcuts) do
+		if string.lower(shortcut) == cleanString then
 			thisstring = value
 		end
 	end

--- a/util_shared.lua
+++ b/util_shared.lua
@@ -63,6 +63,14 @@ function formatDateString(string)
 	return os.date(dateFormat, string)
 end
 
+function formatKeyWords(thisstring)
+	for keyword,value in pairs(MessageKeywords) do
+		if string.lower(keyword) == thisstring then
+			thisstring = value
+		end
+	end
+	return thisstring
+end
 
 function math.round(num, numDecimalPlaces)
 	if numDecimalPlaces and numDecimalPlaces>0 then

--- a/util_shared.lua
+++ b/util_shared.lua
@@ -63,9 +63,10 @@ function formatDateString(string)
 	return os.date(dateFormat, string)
 end
 
-function formatKeyWords(thisstring)
-	for keyword,value in pairs(MessageKeywords) do
-		if string.lower(keyword) == thisstring then
+function formatShortcuts(thisstring)
+	local cleanString = string.gsub(string.lower(thisstring), " ", "")
+	for keyword,value in pairs(MessageShortcuts) do
+		if string.lower(keyword) == cleanString then
 			thisstring = value
 		end
 	end


### PR DESCRIPTION
Essentially, if the server owner adds ea_addKeyword <KEYWORD> <Thing to replace that with> to their cfg, it will replace that with a pre-typed message, but ONLY if that is the entire reason for a kick/ban/warn.
I.E.
Cfg -> ea_addKeyword VDM Vehicle Deathmatch is not allowed, please read our rules!
Admin -> *warns player* reason: vdm
User -> Sees the "Vehicle Deathmatch is not allowed, please read our rules!" message