### PR TITLE
fix(plugins/notifs): mythic export

### DIFF
--- a/plugins/notifications/mythic-notify_client.lua
+++ b/plugins/notifications/mythic-notify_client.lua
@@ -9,6 +9,6 @@ end)
 
 AddEventHandler("EasyAdmin:showNotification", function(text, important)
 	if GetResourceState("mythic-notify") == "started" or enableNotificationReplace then
-		exports['mythic_notify']:SendAlert('inform', text)
+		exports['mythic_notify']:DoHudText('inform', text)
 	end
 end)


### PR DESCRIPTION
Apparently in the official version this wasn't `SendAlert`, but `DoHudText`. 