### PR TITLE
Add Ban ID to webhook notification for easier appeal work

### DIFF
--- a/admin_server.lua
+++ b/admin_server.lua
@@ -759,7 +759,7 @@ Citizen.CreateThread(function()
 				local ban = {banid = GetFreshBanId(), name = username,identifiers = bannedIdentifiers, banner = getName(source, true), reason = reason, expire = expires }
 				updateBlacklist( ban )
 				PrintDebugMessage("Player "..getName(source,true).." banned player "..CachedPlayers[playerId].name.." for "..reason, 3)
-				SendWebhookMessage(moderationNotification,string.format(GetLocalisedText("adminbannedplayer"), getName(source, false, true), CachedPlayers[playerId].name, reason, formatDateString( expires ) ), "ban", 16711680)
+				SendWebhookMessage(moderationNotification,string.format(GetLocalisedText("adminbannedplayer"), getName(source, false, true), CachedPlayers[playerId].name, reason, formatDateString( expires ), tostring(ban.banid) ), "ban", 16711680)
 				DropPlayer(playerId, string.format(GetLocalisedText("banned"), reason, formatDateString( expires ) ) )
 			elseif CachedPlayers[playerId].immune then
 				TriggerClientEvent("EasyAdmin:showNotification", source, GetLocalisedText("adminimmune"))

--- a/language/cs.json
+++ b/language/cs.json
@@ -91,7 +91,7 @@
     "playernotfound": "Hrac nemohl byt nalezen.",
     "done": "Hotovo!",
     "adminkickedplayer": "**%s** vyhodil **%s**, Duvod: %s",
-    "adminbannedplayer": "**%s** zabanoval **%s**, Duvod: %s, Ban vyprsi: %s",
+    "adminbannedplayer": "**%s** zabanoval **%s**, Duvod: %s, Ban vyprsi: %s, ID: %s",
     "adminunbannedplayer": "**%s** odbanoval **%s** [ %s ]",
     "adminslappedplayer": "**%s** profackoval **%s** za **%s HP**",
 

--- a/language/de.json
+++ b/language/de.json
@@ -94,7 +94,7 @@
     "playernotfound": "Spieler wurde nicht gefunden.",
     "done": "Fertig!",
     "adminkickedplayer": "**%s** hat **%s** gekickt, Grund: %s",
-    "adminbannedplayer": "**%s** hat **%s** gebannt, Grund: %s, Bann entfällt: %s",
+    "adminbannedplayer": "**%s** hat **%s** gebannt, Grund: %s, Bann entfällt: %s, ID: %s",
     "adminunbannedplayer": "**%s** hat **%s** entbannt. [ %s ]",
     "adminslappedplayer": "**%s** hat **%s** geschlagen **(%s Leben)**.",
 

--- a/language/en.json
+++ b/language/en.json
@@ -93,7 +93,7 @@
     "playernotfound": "Player could not be found.",
     "done": "Done!",
     "adminkickedplayer": "**%s** kicked **%s**, Reason: %s",
-    "adminbannedplayer": "**%s** banned **%s**, Reason: %s, Ban Expires: %s",
+    "adminbannedplayer": "**%s** banned **%s**, Reason: %s, Ban Expires: %s, ID: %s",
     "adminunbannedplayer": "**%s** unbanned **%s** [ %s ]",
     "adminslappedplayer": "**%s** slapped **%s** for **%s HP**",
 

--- a/language/es.json
+++ b/language/es.json
@@ -93,7 +93,7 @@
     "playernotfound": "No se ha encontrado al jugador.",
     "done": "Hecho",
     "adminkickedplayer": "**%s** a kickeado a **%s**, Razón: %s",
-    "adminbannedplayer": "**%s** a baneado a **%s**, Razón: %s, Expira: %s",
+    "adminbannedplayer": "**%s** a baneado a **%s**, Razón: %s, Expira: %s, ID: %s",
     "adminunbannedplayer": "**%s** a desbaneado a **%s** [ %s ]",
     "adminslappedplayer": "**%s** a abofeteado a **%s** por **%s HP**",
 

--- a/language/fr.json
+++ b/language/fr.json
@@ -94,7 +94,7 @@
     "playernotfound": "Le joueur n'a pas été trouvé.",
     "done": "Fait!",
     "adminkickedplayer": "**%s** a expulser **%s**, Raison: %s",
-    "adminbannedplayer": "**%s** a banni **%s**, Raison: %s, Expire: %s",
+    "adminbannedplayer": "**%s** a banni **%s**, Raison: %s, Expire: %s, ID: %s",
     "adminunbannedplayer": "**%s** a débanni **%s** [ %s ]",
     "adminslappedplayer": "**%s** à pousser **%s** pour **%s HP**",
 

--- a/language/it.json
+++ b/language/it.json
@@ -95,7 +95,7 @@
     "playernotfound": "Giocatore non trovato.",
     "done": "Fatto!",
     "adminkickedplayer": "**%s** Ha espulso **%s**, Motivo: %s",
-    "adminbannedplayer": "**%s** Ha bandito **%s**, Motivo: %s, Scadenza: %s",
+    "adminbannedplayer": "**%s** Ha bandito **%s**, Motivo: %s, Scadenza: %s, ID: %s",
     "adminunbannedplayer": "**%s** ha revocato il ban di **%s** [ %s ]",
     "adminslappedplayer": "**%s** ha schiaffeggiato **%s** togliendogli **%s HP**",
 

--- a/language/nl.json
+++ b/language/nl.json
@@ -96,7 +96,7 @@
     "done": "Gedaan!",
 
     "adminkickedplayer": "**%s** Gekickt **%s**, Reden: %s",
-    "adminbannedplayer": "**%s** banned **%s**, Reden: %s, Ban Vervalt: %s",
+    "adminbannedplayer": "**%s** banned **%s**, Reden: %s, Ban Vervalt: %s, ID: %s",
     "adminunbannedplayer": "**%s** Ban ongedaan gemaakt **%s** [ %s ]",
     "adminslappedplayer": "**%s** sloeg **%s** for **%s HP**",
     "adminfrozeplayer": "**%s** bevroor **%s**.",

--- a/language/pl.json
+++ b/language/pl.json
@@ -93,7 +93,7 @@
     "playernotfound": "Nie można znaleźć gracza.",
     "done": "Zrobione!",
     "adminkickedplayer": "**%s** wyrzucił **%s**, Powód: %s",
-    "adminbannedplayer": "**%s** zbanował **%s**, Powód: %s, Czas trwania: %s",
+    "adminbannedplayer": "**%s** zbanował **%s**, Powód: %s, Czas trwania: %s, ID: %s",
     "adminunbannedplayer": "**%s** odblokował **%s** [ %s ]",
     "adminslappedplayer": "**%s** uderzył **%s** za **%s HP**",
 

--- a/language/pt.json
+++ b/language/pt.json
@@ -92,7 +92,7 @@
     "playernotfound": "Jogador não pode ser encontrado.",
     "done": "Feito!",
     "adminkickedplayer": "**%s** kicked **%s**, Razão: %s",
-    "adminbannedplayer": "**%s** banido **%s**, Razão: %s, Ban Expira: %s",
+    "adminbannedplayer": "**%s** banido **%s**, Razão: %s, Ban Expira: %s, ID: %s",
     "adminunbannedplayer": "**%s** unbanned **%s** [ %s ]",
     "adminslappedplayer": "**%s** slapped **%s** for **%s HP**",
     "adminfrozeplayer": "**%s** froze **%s**.",

--- a/language/sv.json
+++ b/language/sv.json
@@ -94,7 +94,7 @@
     "playernotfound": "Spelaren kunde inte hittas.",
     "done": "Klart!",
     "adminkickedplayer": "**%s** kickad **%s**, Anledning: %s",
-    "adminbannedplayer": "**%s** bannlyste **%s**, Anledning: %s, löper ut: %s",
+    "adminbannedplayer": "**%s** bannlyste **%s**, Anledning: %s, löper ut: %s, ID: %s",
     "adminunbannedplayer": "**%s** hävde bannlysning **%s** [ %s ]",
     "adminslappedplayer": "**%s** slog **%s** för **%s HP**",
 


### PR DESCRIPTION
This simply allows the webhook to log the ban's ID, so those doing appeals can look back and find the ban more easily without going into the game each time