### PR TITLE
Automatically enter vehicle after ending spectate.

### DIFF
--- a/admin_client.lua
+++ b/admin_client.lua
@@ -402,10 +402,10 @@ function spectatePlayer(targetPed,target,name)
 				if IsVehicleSeatFree(vehicle, vehicleInfo.seat) then
 					SetPedIntoVehicle(playerPed, vehicle, vehicleInfo.seat)
 				else
-					TriggerEvent("EasyAdmin:showNotification", 'The seat you was in is no longer empty.')
+					TriggerEvent("EasyAdmin:showNotification", GetLocalisedText("spectatevehicleseatoccupied"))
 				end
 			else
-				TriggerEvent("EasyAdmin:showNotification", 'Cant find the vehicle.')
+				TriggerEvent("EasyAdmin:showNotification", GetLocalisedText("spectatenovehiclefound"))
 			end
 
 			vehicleInfo.netId = nil

--- a/language/cs.json
+++ b/language/cs.json
@@ -224,7 +224,10 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
+
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 
 }]

--- a/language/cs.json
+++ b/language/cs.json
@@ -227,7 +227,7 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 
 }]

--- a/language/de.json
+++ b/language/de.json
@@ -227,5 +227,5 @@
     "copiedtoclipboard":"Text wurde in die Zwischenablage kopiert!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 }]

--- a/language/de.json
+++ b/language/de.json
@@ -224,5 +224,8 @@
     "adminimmune": "Dazu hast du keine Rechte, der ausgewählte Spieler ist Immun",
     "teleportmeback": "Teleportiere mich zurück",
     "teleportplayerback": "Teleportiere Spieler zurück",
-    "copiedtoclipboard":"Text wurde in die Zwischenablage kopiert!"
+    "copiedtoclipboard":"Text wurde in die Zwischenablage kopiert!",
+
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 }]

--- a/language/en.json
+++ b/language/en.json
@@ -227,6 +227,6 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 }]

--- a/language/en.json
+++ b/language/en.json
@@ -224,9 +224,9 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
 
-
-
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 }]

--- a/language/es.json
+++ b/language/es.json
@@ -223,7 +223,10 @@
     "adminimmune":"No tienes permiso para hacer esto, el jugador que has seleccionado es Administrador.",
     "teleportmeback":"Teleportarme a donde estaba",
     "teleportplayerback":"Teleportar al jugador a donde estaba",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
+
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 
 }]

--- a/language/es.json
+++ b/language/es.json
@@ -226,7 +226,7 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 
 }]

--- a/language/fr.json
+++ b/language/fr.json
@@ -226,8 +226,10 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
 
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 
 }]

--- a/language/fr.json
+++ b/language/fr.json
@@ -229,7 +229,7 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 
 }]

--- a/language/it.json
+++ b/language/it.json
@@ -230,7 +230,7 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 
 }]

--- a/language/it.json
+++ b/language/it.json
@@ -227,8 +227,10 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
+
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 
-  
 }]

--- a/language/nl.json
+++ b/language/nl.json
@@ -230,6 +230,6 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 }]

--- a/language/nl.json
+++ b/language/nl.json
@@ -227,8 +227,9 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
 
-
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 }]

--- a/language/pl.json
+++ b/language/pl.json
@@ -228,6 +228,6 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 }]

--- a/language/pl.json
+++ b/language/pl.json
@@ -225,8 +225,9 @@
     "adminimmune":"Nie masz uprawnień aby wykonać tą akcje, docelowy gracz jest nietykalny.",
     "teleportmeback":"Teleportuj mnie z powrotem",
     "teleportplayerback":"Teleportuj gracza z powrotem",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
 
-
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 }]

--- a/language/pt.json
+++ b/language/pt.json
@@ -224,6 +224,6 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 }]

--- a/language/pt.json
+++ b/language/pt.json
@@ -221,7 +221,9 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
 
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 }]

--- a/language/sv.json
+++ b/language/sv.json
@@ -228,6 +228,6 @@
     "copiedtoclipboard":"Text copied to Clipboard!",
 
     "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
-    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
+    "spectatenovehiclefound":"The vehicle you were in can no longer be found."
 
 }]

--- a/language/sv.json
+++ b/language/sv.json
@@ -225,8 +225,9 @@
     "adminimmune":"You do not have permission to perform this action, target player is immune.",
     "teleportmeback":"Teleport me back",
     "teleportplayerback":"Teleport Player back",
-    "copiedtoclipboard":"Text copied to Clipboard!"
+    "copiedtoclipboard":"Text copied to Clipboard!",
 
-
+    "spectatevehicleseatoccupied":"The vehicle seat you were in is now occupied.",
+    "spectatenovehiclefound":"The vehicle you was in can no longer be found."
 
 }]


### PR DESCRIPTION
Very simple after you spectate someone if you was in a vehicle it would teleport outside of that vehicle because of how spectate works.
This stores the vehicles Net ID and seat index the player was in, if the vehicle exists and the seat is not taken You will be put back inside the vehicle after ending spectate.