### PR TITLE
Added discord webhook logging for claiming reports

### DIFF
--- a/language/en.json
+++ b/language/en.json
@@ -212,6 +212,7 @@
     "closesimilarreports": "~r~Close all similar reports~w~",
     "closesimilarreportsguide": "Will attempt to find and delete reports made by the same user.",
     "adminclosedreport": "**%s** closed Report #**%s**",
+    "adminclaimedreport": "**%s** claimed Report #**%s**",
     "entertoopen": "Select to display options for this player.",
     "refreshreports": "Refresh Reports",
     "refreshreportsguide": "Shows new reports in case there are any since last time the menu was opened.",

--- a/server/reports.lua
+++ b/server/reports.lua
@@ -159,6 +159,7 @@ Citizen.CreateThread(function()
 					TriggerLatentClientEvent("EasyAdmin:ClaimedReport", admin, 10000, reports[reportId])
 				end
                 TriggerEvent("EasyAdmin:reportClaimed", reports[reportId])
+                SendWebhookMessage(moderationNotification,string.format(GetLocalisedText("adminclaimedreport"), getName(source, false, true), reportId), "reports", 16777214)
 			else
 				TriggerClientEvent("EasyAdmin:showNotification", source, GetLocalisedText("reportalreadyclaimed"))
 			end


### PR DESCRIPTION
**Overview:**
This commit covers the English version of what claiming a report would log over Discord using the webhook feature. Please note that this would in theory be mimicked for those who use the Discord bot instead. Also know that additional translations for other languages would have to be done as well, however, I am unable to do the rest.

**Screenshot:**
![Discord_8hGt7WhMz5](https://user-images.githubusercontent.com/26366517/212794476-665750e2-77ad-470f-a338-864c7415b352.png)

_Initial idea and help from_ @kianlow9