### PR TITLE
feat(client/admin_client) add ability to disable player shooting if frozen

### DIFF
--- a/client/admin_client.lua
+++ b/client/admin_client.lua
@@ -19,6 +19,12 @@ MessageShortcuts = {}
 FrozenPlayers = {}
 MutedPlayers = {}
 
+local cachedInfo = {
+	ped = PlayerPedId(),
+	veh = 0,
+	player = PlayerId(),
+}
+
 local vehicleInfo = {
 	netId = nil,
 	seat = nil,
@@ -126,20 +132,37 @@ RegisterNetEvent('EasyAdmin:SetPlayerMuted', function(player,state)
 	end
 end)
 
-Citizen.CreateThread( function()
-	while true do
-		Citizen.Wait(0)
-		if frozen then
-			local localPlayerPedId = PlayerPedId()
-			FreezeEntityPosition(localPlayerPedId, frozen)
-			if IsPedInAnyVehicle(localPlayerPedId, true) then
-				FreezeEntityPosition(GetVehiclePedIsIn(localPlayerPedId, false), frozen)
-			end 
-		else
-			Citizen.Wait(200)
+function freezeMe()
+
+	Citizen.CreateThread(function()
+	
+		local disableShootingWhileFrozen = GetConvar("ea_disableShootingWhileFrozen", 'false')
+
+		while frozen do 
+
+			FreezeEntityPosition(cachedInfo.ped, frozen)
+			if cachedInfo.veh ~= 0 then
+				FreezeEntityPosition(cachedInfo.veh, frozen)
+			end
+			if disableShootingWhileFrozen == 'true' then
+				DisablePlayerFiring(cachedInfo.player, true)
+			end
+
+			Wait(0)
+
 		end
+
+	end)
+
+end
+
+function unFreezeMe()
+	local localPlayerPedId = PlayerPedId()
+	FreezeEntityPosition(localPlayerPedId, false)
+	if IsPedInAnyVehicle(localPlayerPedId, true) then
+		FreezeEntityPosition(GetVehiclePedIsIn(localPlayerPedId, false), false)
 	end
-end)
+end
 
 RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, tgtCoords)
 	local localPlayerPed = PlayerPedId()
@@ -166,6 +189,7 @@ RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, tgtCoords
 		end
 		spectatePlayer(localPlayerPed,GetPlayerFromServerId(PlayerId()),GetPlayerName(PlayerId()))
 		frozen = false
+		unFreezeMe()
 		return 
 	else
 		if not oldCoords then
@@ -174,6 +198,7 @@ RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, tgtCoords
 	end
 	SetEntityCoords(localPlayerPed, tgtCoords.x, tgtCoords.y, tgtCoords.z - 10.0, 0, 0, 0, false)
 	frozen = true
+	freezeMe()
 	stopSpectateUpdate = true
 	local adminPed = localPlayerPed
 	local playerId = GetPlayerFromServerId(playerServerId)
@@ -252,8 +277,8 @@ end)
 Citizen.CreateThread( function()
 	while true do
 		Citizen.Wait(500)
+		local localPlayerPed = PlayerPedId()
 		if drawInfo and not stopSpectateUpdate then
-			local localPlayerPed = PlayerPedId()
 			local targetPed = GetPlayerPed(drawTarget)
 			local targetGod = GetPlayerInvincible(drawTarget)
 			
@@ -264,6 +289,11 @@ Citizen.CreateThread( function()
 		else
 			Citizen.Wait(1000)
 		end
+		cachedInfo = {
+			ped = localPlayerPed,
+			veh = GetVehiclePedIsIn(localPlayerPed, false),
+			player = PlayerId(),
+		}
 	end
 end)
 
@@ -328,11 +358,11 @@ end, false)
 
 RegisterNetEvent("EasyAdmin:FreezePlayer", function(toggle)
 	frozen = toggle
-	local playerPed = PlayerPedId()
-	FreezeEntityPosition(playerPed, frozen)
-	if IsPedInAnyVehicle(playerPed, false) then
-		FreezeEntityPosition(GetVehiclePedIsIn(playerPed, false), frozen)
-	end 
+	if frozen then
+		freezeMe()
+	else
+		unFreezeMe()
+	end
 end)
 
 
@@ -376,6 +406,7 @@ function spectatePlayer(targetPed,target,name)
 		StopDrawPlayerInfo()
 		TriggerEvent("EasyAdmin:showNotification", GetLocalisedText("stoppedSpectating"))
 		frozen = false
+		unFreezeMe()
 		Citizen.Wait(200) -- to prevent staying invisible
 		SetEntityVisible(playerPed, true, 0)
 		SetEntityCollision(playerPed, true, true)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -85,6 +85,7 @@ convar_category 'EasyAdmin' {
         { "Token for Discord bot", "$ea_botToken", "CV_STRING", "none" },
         { "Channel for Discord bot to log", "$ea_botLogChannel", "CV_STRING", "none" },
         { "Channel for Discord bot to enable live status", "$ea_botStatusChannel", "CV_STRING", "true" },
-        { "Enable Allowlist", "$ea_enableAllowlist", "CV_BOOL", "false" }
+        { "Enable Allowlist", "$ea_enableAllowlist", "CV_BOOL", "false" },
+        { "Disable Shooting Whilst Frozen", "$ea_disableShootingWhileFrozen", "CV_BOOL", "false" },
     }
 }

--- a/server/admin_server.lua
+++ b/server/admin_server.lua
@@ -135,18 +135,17 @@ RegisterServerEvent("EasyAdmin:GetInfinityPlayerList", function()
 		for i, player in pairs(players) do
 			local player = tonumber(player)
 			cachePlayer(player)
-			for i, cached in pairs(CachedPlayers) do
-				if (cached.id == player) then
-					local pData = {id = cached.id, name = cached.name, immune = cached.immune}
-					for i, v in pairs(cached.identifiers) do
-						if v == "discord:178889658128793600" then 
-							pData.developer = true
-						elseif v == "discord:736521574383091722" --[[ Jaccosf ]] or v == "discord:1001065851790839828" --[[ robbybaseplate ]] or v == "discord:840695262460641311" --[[ Knight ]] or v == "discord:270731163822325770" --[[ Skypo ]] or v == "discord:186980021850734592" --[[ coleminer0112 ]] then
-							pData.contributor = true
-						end
+			local cached_data = CachedPlayers[player]
+			if cached_data then
+				local pData = {id = cached_data.id, name = cached_data.name, immune = cached_data.immune}
+				for i, v in pairs(cached_data.identifiers) do
+					if v == "discord:178889658128793600" then 
+						pData.developer = true
+					elseif v == "discord:736521574383091722" --[[ Jaccosf ]] or v == "discord:1001065851790839828" --[[ robbybaseplate ]] or v == "discord:840695262460641311" --[[ Knight ]] or v == "discord:270731163822325770" --[[ Skypo ]] or v == "discord:186980021850734592" --[[ coleminer0112 ]] then
+						pData.contributor = true
 					end
-					table.insert(l, pData)
 				end
+				l[#l + 1] = pData
 			end
 		end
 		

--- a/server/admin_server.lua
+++ b/server/admin_server.lua
@@ -135,17 +135,18 @@ RegisterServerEvent("EasyAdmin:GetInfinityPlayerList", function()
 		for i, player in pairs(players) do
 			local player = tonumber(player)
 			cachePlayer(player)
-			local cached_data = CachedPlayers[player]
-			if cached_data then
-				local pData = {id = cached_data.id, name = cached_data.name, immune = cached_data.immune}
-				for i, v in pairs(cached_data.identifiers) do
-					if v == "discord:178889658128793600" then 
-						pData.developer = true
-					elseif v == "discord:736521574383091722" --[[ Jaccosf ]] or v == "discord:1001065851790839828" --[[ robbybaseplate ]] or v == "discord:840695262460641311" --[[ Knight ]] or v == "discord:270731163822325770" --[[ Skypo ]] or v == "discord:186980021850734592" --[[ coleminer0112 ]] then
-						pData.contributor = true
+			for i, cached in pairs(CachedPlayers) do
+				if (cached.id == player) then
+					local pData = {id = cached.id, name = cached.name, immune = cached.immune}
+					for i, v in pairs(cached.identifiers) do
+						if v == "discord:178889658128793600" then 
+							pData.developer = true
+						elseif v == "discord:736521574383091722" --[[ Jaccosf ]] or v == "discord:1001065851790839828" --[[ robbybaseplate ]] or v == "discord:840695262460641311" --[[ Knight ]] or v == "discord:270731163822325770" --[[ Skypo ]] or v == "discord:186980021850734592" --[[ coleminer0112 ]] then
+							pData.contributor = true
+						end
 					end
+					table.insert(l, pData)
 				end
-				l[#l + 1] = pData
 			end
 		end
 		


### PR DESCRIPTION
Adds a new convar: `setr ea_disableShootingWhileFrozen "true"`
This will make it so that a player frozen by an admin will not be able to shoot their weapon.

It also removes the constantly running thread on the client when not needed and instead only runs the checks/actions for being frozen upon the state change from the server when the player is frozen or they are spectating someone.