### PR TITLE
feat: add support for spectating for servers with buckets

### DIFF
--- a/client/admin_client.lua
+++ b/client/admin_client.lua
@@ -18,6 +18,7 @@ add_aces, add_principals = {}, {}
 MessageShortcuts = {}
 FrozenPlayers = {}
 MutedPlayers = {}
+MyBucket = 0
 
 local cachedInfo = {
 	ped = PlayerPedId(),
@@ -164,9 +165,10 @@ function unFreezeMe()
 	end
 end
 
-RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, tgtCoords)
+RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, playerData)
+	
 	local localPlayerPed = PlayerPedId()
-
+	
 	if IsPedInAnyVehicle(localPlayerPed) then
 		local vehicle = GetVehiclePedIsIn(localPlayerPed, false)
 		local numVehSeats = GetVehicleModelNumberOfSeats(GetEntityModel(vehicle))
@@ -179,6 +181,13 @@ RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, tgtCoords
 		end
 	end
 
+	if playerData.selfbucket then
+		-- cache old bucket to restore at end of spectate
+		MyBucket = playerData.selfbucket
+	end
+
+	local tgtCoords = playerData.coords
+	
 	if ((not tgtCoords) or (tgtCoords.z == 0.0)) then tgtCoords = GetEntityCoords(GetPlayerPed(GetPlayerFromServerId(playerServerId))) end
 	if playerServerId == GetPlayerServerId(PlayerId()) then 
 		if oldCoords then
@@ -193,7 +202,7 @@ RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, tgtCoords
 		return 
 	else
 		if not oldCoords then
-			oldCoords = GetEntityCoords(localPlayerPed)
+			oldCoords = GetEntityCoords(PlayerPedId())
 		end
 	end
 	SetEntityCoords(localPlayerPed, tgtCoords.x, tgtCoords.y, tgtCoords.z - 10.0, 0, 0, 0, false)

--- a/client/gui_c.lua
+++ b/client/gui_c.lua
@@ -184,12 +184,15 @@ end)
 
 function DrawPlayerInfo(target)
 	drawTarget = target
+	drawServerId = GetPlayerServerId(target)
 	drawInfo = true
+	DrawPlayerInfoLoop()
 end
 
 function StopDrawPlayerInfo()
 	drawInfo = false
 	drawTarget = 0
+	drawServerId = 0
 end
 
 local banlistPage = 1
@@ -1874,10 +1877,12 @@ function GenerateMenu() -- this is a big ass function
 end
 
 
-Citizen.CreateThread( function()
-	while true do
-		Citizen.Wait(0)
-		if drawInfo then
+function DrawPlayerInfoLoop()
+	CreateThread(function()
+		while drawInfo do
+			
+			Wait(0)
+
 			local text = {}
 			-- cheat checks
 			local targetPed = GetPlayerPed(drawTarget)
@@ -1946,9 +1951,22 @@ Citizen.CreateThread( function()
 	
 				StopDrawPlayerInfo()
 				TriggerEvent("EasyAdmin:showNotification", GetLocalisedText("stoppedSpectating"))
+				TriggerServerEvent("EasyAdmin:resetBucket", MyBucket)
 			end
-		else
-			Citizen.Wait(1000)
 		end
-	end
-end)
+	end)
+
+	CreateThread(function()
+		while drawInfo do
+			Wait(5000)
+
+			local targetPed = GetPlayerPed(drawTarget)
+			if not DoesEntityExist(targetPed) and drawServerId ~= 0 then
+				-- player no longer exists, lets contact the server to see if they changed bucket?
+				TriggerServerEvent("EasyAdmin:requestBucket", drawServerId)
+			end
+
+		end
+	end)
+
+end


### PR DESCRIPTION
Lots of servers use buckets (if you don't, try it!) - this addresses and provides a solution to #788 

- When pressing "spectate", the server will check your bucket against the target, if they are not the same, it will set yours (the admin) to the bucket of the target player but will also have your client cache the original bucket you were in when beginning your spectate. 
- Every 5 seconds whilst spectating, your client will check if the target player's ped still exists, if it doesn't (sign of them changing) it will ask the server to confirm and again make the necessary bucket change. This means that if that player changes lobbies multiple times, it will continue to work. (small delay for optimisation)
- When you exit the spectator mode, it will restore you to the original bucket that you cached originally meaning you can continue your gameplay