### PR TITLE
fix(client/spectating) caching original routing bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ EasyAdmin is an Administration Suite for FiveM and RedM Servers, EasyAdmin is fe
 - Actively Supported & Updated since 2017
 - Plugin Support 
 - Fully integrated Discord Bot, including Discord ACE Permissions, Chat Bridge, Commands and Logs
+- Configurable ban screens allowing server owners to modify to their colours/logo etc via our [easy to use convars](https://easyadmin.readthedocs.io/en/latest/config/#ban-screen-configuration)
 
 ![image](https://user-images.githubusercontent.com/13604413/126916981-1680e5ac-e024-467b-aad3-a5a9658449e0.png)
 
@@ -24,6 +25,8 @@ EasyAdmin is an Administration Suite for FiveM and RedM Servers, EasyAdmin is fe
 ![image](https://user-images.githubusercontent.com/13604413/126916995-213fca15-d356-47b6-8b80-8745b4a37eb9.png)
 
 ![image](https://user-images.githubusercontent.com/13604413/126916989-f78d7b16-d20a-49ba-a559-6c3b56e98de5.png)
+
+![image](https://github.com/Gravxd/EasyAdmin/assets/75702884/8a4e4694-5ff5-429a-986c-ab43148929a8)
 
 ### Dependencies
 

--- a/client/admin_client.lua
+++ b/client/admin_client.lua
@@ -183,7 +183,9 @@ RegisterNetEvent("EasyAdmin:requestSpectate", function(playerServerId, playerDat
 
 	if playerData.selfbucket then
 		-- cache old bucket to restore at end of spectate
-		MyBucket = playerData.selfbucket
+		if not IsSpectating then
+			MyBucket = playerData.selfbucket
+		end
 	end
 
 	local tgtCoords = playerData.coords

--- a/client/gui_c.lua
+++ b/client/gui_c.lua
@@ -185,10 +185,13 @@ Citizen.CreateThread(function()
 	end
 end)
 
+IsSpectating = false
+
 function DrawPlayerInfo(target)
 	drawTarget = target
 	drawServerId = GetPlayerServerId(target)
 	drawInfo = true
+	IsSpectating = true
 	DrawPlayerInfoLoop()
 end
 
@@ -196,6 +199,7 @@ function StopDrawPlayerInfo()
 	drawInfo = false
 	drawTarget = 0
 	drawServerId = 0
+	IsSpectating = false
 end
 
 local banlistPage = 1

--- a/server/admin_server.lua
+++ b/server/admin_server.lua
@@ -327,7 +327,7 @@ Citizen.CreateThread(function()
 			local playerBucket = GetPlayerRoutingBucket(playerId)
 			local sourceBucket = GetPlayerRoutingBucket(source)
 			if sourceBucket ~= playerBucket then
-				-- upon spectate request, the admin needs to be set to the target player
+				-- upon spectate request, the admin needs to be set to the target player's bucket if not already
 				SetPlayerRoutingBucket(source, playerBucket)
 			end
 			local playerData = { coords = tgtCoords, selfbucket = sourceBucket }


### PR DESCRIPTION
Fixes an issue brought up where if you spectate a player while already spectating someone it would cache your modified bucket rather than the original bucket you were in when you began spectating.