### PR TITLE
feat(gui): add notification for report reason in menu

### DIFF
--- a/client/gui_c.lua
+++ b/client/gui_c.lua
@@ -956,6 +956,9 @@ function GenerateMenu() -- this is a big ass function
 				local thisItem = NativeUI.CreateItem(GetLocalisedText("reason"), "")
 				thisItem:RightLabel(formatRightString(report.reason, 48))
 				thisMenu:AddItem(thisItem)
+				thisItem.Activated = function(ParentMenu, SelectedItem)
+					TriggerEvent("EasyAdmin:showNotification", GetLocalisedText("reason") .. ": " .. report.reason)
+				end
 
 				local thisItem = NativeUI.CreateItem(GetLocalisedText("time"), "")
 				thisItem:RightLabel(report.reportTimeFormatted, 48)


### PR DESCRIPTION
Some players like to write full paragraphs as their reason and the GUI menu has no way of showing the reason again, so why not just send a modified notification when the reason button is clicked so admins can view the full reason!